### PR TITLE
Add session_id in response when user authenticate

### DIFF
--- a/src/app/core/users/http/controllers/SessionsController.ts
+++ b/src/app/core/users/http/controllers/SessionsController.ts
@@ -14,7 +14,7 @@ class SessionsController {
     const authenticateUser = container.resolve(AuthenticateUserService)
 
     try {
-      const { token, user } = await authenticateUser.execute({
+      const { token, user, session_id } = await authenticateUser.execute({
         email,
         password,
       })
@@ -22,6 +22,7 @@ class SessionsController {
       return response.json({
         user,
         token,
+        session_id,
       })
     } catch (error) {
       return next(error)

--- a/src/app/core/users/services/AuthenticateUserService.ts
+++ b/src/app/core/users/services/AuthenticateUserService.ts
@@ -44,13 +44,16 @@ class AuthenticateUserService {
 
     const token = this.authProvider.generateToken(userByEmail.id)
 
-    await this.sessionsRepository.create(userByEmail.id)
+    const { id: session_id } = await this.sessionsRepository.create(
+      userByEmail.id,
+    )
 
     delete userByEmail.password
 
     return {
       user: userByEmail,
       token,
+      session_id,
     }
   }
 }

--- a/src/app/core/users/types/index.ts
+++ b/src/app/core/users/types/index.ts
@@ -27,6 +27,7 @@ export type SessionsRepositoryProvider = {
 export type AuthenticateResponse = {
   user: Omit<User, 'password'>
   token: string
+  session_id: string
 }
 
 export const createUserSchema = {


### PR DESCRIPTION
## Motivation

Precisamos enviar o `session_id` para o client salvar e depois realizar o log out.

## Proposed solution

Incluir o `session_id` na resposta de autenticação

#8 